### PR TITLE
Add a new `all` constructor to scroll view options

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.8.2"
+    version: "2.9.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -21,21 +21,14 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
-  charcode:
-    dependency: transitive
-    description:
-      name: charcode
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.3.1"
+    version: "1.2.1"
   clock:
     dependency: transitive
     description:
       name: clock
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   collection:
     dependency: transitive
     description:
@@ -56,7 +49,7 @@ packages:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.3.1"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -73,28 +66,28 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.11"
+    version: "0.12.12"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.4"
+    version: "0.2.0"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.0"
+    version: "1.8.0"
   path:
     dependency: transitive
     description:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.1"
+    version: "1.8.2"
   scroll_date_picker:
     dependency: "direct main"
     description:
@@ -113,7 +106,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.2"
+    version: "1.9.1"
   stack_trace:
     dependency: transitive
     description:
@@ -134,21 +127,21 @@ packages:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.2.1"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.9"
+    version: "0.4.12"
   vector_math:
     dependency: transitive
     description:

--- a/lib/src/models/date_picker_scroll_view_options.dart
+++ b/lib/src/models/date_picker_scroll_view_options.dart
@@ -10,6 +10,15 @@ class DatePickerScrollViewOptions {
   final ScrollViewDetailOptions year;
   final ScrollViewDetailOptions month;
   final ScrollViewDetailOptions day;
+
+  // Applies the given [ScrollViewDetailOptions] to all three options ie. year, month and day.
+ static DatePickerScrollViewOptions all(ScrollViewDetailOptions value) {
+    return DatePickerScrollViewOptions(
+      year: value,
+      month: value,
+      day: value,
+    );
+  }
 }
 
 class ScrollViewDetailOptions {


### PR DESCRIPTION
## Type of change

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring 
- [ ] Documentation content changes

## Description

Created a new `all` contructor for `DatePickerScrollViewOptions` which takes in a single `ScrollViewDetailOptions` and applies that to all three properties namely: `year`, `month` and `day`. 

```dart
ScrollDatePicker(
  ...
  scrollViewOptions: DatePickerScrollViewOptions.all(
    ScrollViewDetailOptions(selectedTextStyle: TextStyle(color: Colors.green))
  )
)
```
