### PR TITLE
Add and correct month names

### DIFF
--- a/lib/src/constants.dart
+++ b/lib/src/constants.dart
@@ -7,6 +7,8 @@ const String vi = 'vi';
 const String en = 'en';
 const String id = 'id';
 const String th = 'th';
+const String es = 'es';
+const String nl = 'nl';
 
 extension LocaleExtension on Locale {
   List<String> get months {
@@ -23,6 +25,10 @@ extension LocaleExtension on Locale {
         return idMonths;
       case th:
         return thMonths;
+      case es:
+        return esMonth;
+      case nl:
+        return nlMonth;
       default:
         return enMonths;
     }
@@ -78,14 +84,13 @@ const List<String> deMonths = [
   'April',
   'Mai',
   'Juni',
-  'July',
+  'Juli',
   'August',
   'September',
   'Oktober',
   'November',
   'Dezember',
 ];
-
 const List<String> viMonths = [
   'Tháng 1',
   'Tháng 2',
@@ -100,7 +105,6 @@ const List<String> viMonths = [
   'Tháng 11',
   'Tháng 12',
 ];
-
 const List<String> idMonths = [
   'Januari',
   'Februari',
@@ -128,4 +132,32 @@ const List<String> thMonths = [
   'ตุลาคม',
   'พฤศจิกายน',
   'ธันวาคม',
+];
+const List<String> esMonth = [
+  'Enero',
+  'Febrero',
+  'Marzo',
+  'Abril',
+  'Mayo',
+  'Junio',
+  'Julio',
+  'Agosto',
+  'Septiembre',
+  'Octubre',
+  'Noviembre',
+  'Diciembre',
+];
+const List<String> nlMonth = [
+  'Januari',
+  'Februari',
+  'Maart',
+  'April',
+  'Kunnen',
+  'Juni',
+  'Juli',
+  'Augustus',
+  'September',
+  'Oktober',
+  'November',
+  'December',
 ];

--- a/lib/src/constants.dart
+++ b/lib/src/constants.dart
@@ -152,7 +152,7 @@ const List<String> nlMonth = [
   'Februari',
   'Maart',
   'April',
-  'Kunnen',
+  'Mei',
   'Juni',
   'Juli',
   'Augustus',

--- a/lib/src/scroll_date_picker.dart
+++ b/lib/src/scroll_date_picker.dart
@@ -209,6 +209,10 @@ class _ScrollDatePickerState extends State<ScrollDatePicker> {
       case vi:
       case id:
       case th:
+      case de:
+      case es:
+      case nl:
+      case fr:
         return [_dayScrollView, _monthScrollView, _yearScrollView];
       default:
         return [_monthScrollView, _dayScrollView, _yearScrollView];


### PR DESCRIPTION
## Type of change

Please select PR type by entering x between [ ].

- [x] Bugfix
- [x] Feature
- [ ] Refactoring 
- [ ] Documentation content changes


<br><br>

## Description

- I added the month names for spanish and dutch. 
- I corrected the german month name for july.
- I added some missing cases to get the correct date format for the chosen locale.

