### PR TITLE
Fix WidgetsBinding potentially null

### DIFF
--- a/lib/src/scroll_date_picker.dart
+++ b/lib/src/scroll_date_picker.dart
@@ -103,7 +103,7 @@ class _ScrollDatePickerState extends State<ScrollDatePicker> {
       _selectedDate = widget.selectedDate;
       isYearScrollable = false;
       isMonthScrollable = false;
-      WidgetsBinding.instance.addPostFrameCallback((_) {
+      WidgetsBinding.instance?.addPostFrameCallback((_) {
         _yearController.animateToItem(selectedYearIndex, curve: Curves.ease, duration: const Duration(microseconds: 500));
         _monthController.animateToItem(selectedMonthIndex, curve: Curves.ease, duration: const Duration(microseconds: 500));
         _dayController.animateToItem(selectedDayIndex, curve: Curves.ease, duration: const Duration(microseconds: 500));


### PR DESCRIPTION
Fix this issue:
`.pub-cache/hosted/pub.dartlang.org/scroll_date_picker-3.6.0/lib/src/scroll_date_picker.dart:120:31: Error: Method 'addPostFrameCallback' cannot be called on 'WidgetsBinding?' because it is potentially null.`


## Type of change

Please select PR type by entering x between [ ].

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring 
- [ ] Documentation content changes


<br><br>

## Description

I got error when add this package. 
`.pub-cache/hosted/pub.dartlang.org/scroll_date_picker-3.6.0/lib/src/scroll_date_picker.dart:120:31: Error: Method 'addPostFrameCallback' cannot be called on 'WidgetsBinding?' because it is potentially null.`

Changes:
`WidgetsBinding.instance.addPostFrameCallback` ~> `WidgetsBinding.instance?.addPostFrameCallback`
