### PR TITLE
feat viewType option

### DIFF
--- a/lib/src/scroll_date_picker.dart
+++ b/lib/src/scroll_date_picker.dart
@@ -14,7 +14,7 @@ class ScrollDatePicker extends StatefulWidget {
     Locale? locale,
     DatePickerOptions? options,
     DatePickerScrollViewOptions? scrollViewOptions,
-    this.indicator,
+    this.indicator, this.viewType,
   })  : minimumDate = minimumDate ?? DateTime(1960, 1, 1),
         maximumDate = maximumDate ?? DateTime.now(),
         locale = locale ?? const Locale('en'),
@@ -22,6 +22,12 @@ class ScrollDatePicker extends StatefulWidget {
         scrollViewOptions =
             scrollViewOptions ?? const DatePickerScrollViewOptions(),
         super(key: key);
+
+  /// A list that allows you to specify the type of date view.
+  /// And also the order of the viewType in list is the order of the date view.
+  /// If this list is null, the default order of locale is set.
+  /// TODO("Satoshi"): Specify the type of date view visible.
+  final List<DatePickerViewType>? viewType;
 
   /// The currently selected date.
   final DateTime selectedDate;
@@ -138,6 +144,7 @@ class _ScrollDatePickerState extends State<ScrollDatePicker> {
 
   void _initDateScrollView() {
     _yearScrollView = DateScrollView(
+      key: const Key("year"),
         dates: _years,
         controller: _yearController,
         options: widget.options,
@@ -156,6 +163,7 @@ class _ScrollDatePickerState extends State<ScrollDatePicker> {
           isYearScrollable = true;
         });
     _monthScrollView = DateScrollView(
+      key: const Key("month"),
       dates: widget.locale.months.sublist(_months.first - 1, _months.last),
       controller: _monthController,
       options: widget.options,
@@ -173,6 +181,7 @@ class _ScrollDatePickerState extends State<ScrollDatePicker> {
       },
     );
     _dayScrollView = DateScrollView(
+      key: const Key("day"),
       dates: _days,
       controller: _dayController,
       options: widget.options,
@@ -229,6 +238,28 @@ class _ScrollDatePickerState extends State<ScrollDatePicker> {
 
   List<Widget> _getScrollDatePicker() {
     _initDateScrollView();
+
+    // set order of scroll view
+    if(widget.viewType?.isNotEmpty ?? false) {
+      final viewList = <Widget>[];
+
+      for (var view in widget.viewType!) {
+        switch (view) {
+          case DatePickerViewType.year:
+            viewList.add(_yearScrollView);
+            break;
+          case DatePickerViewType.month:
+            viewList.add(_monthScrollView);
+            break;
+          case DatePickerViewType.day:
+            viewList.add(_dayScrollView);
+            break;
+        }
+      }
+
+      return viewList;
+    }
+
     switch (widget.locale.languageCode) {
       case zh:
       case ko:
@@ -304,3 +335,9 @@ class _ScrollDatePickerState extends State<ScrollDatePicker> {
     );
   }
 }
+
+/// ViewType that represents order of scroll view
+enum DatePickerViewType {
+  year, month, day
+}
+

--- a/lib/src/widgets/date_scroll_view.dart
+++ b/lib/src/widgets/date_scroll_view.dart
@@ -16,6 +16,7 @@ class DateScrollView extends StatelessWidget {
     this.isMonthScrollView = false,
   }) : super(key: key);
 
+
   /// A controller for scroll views whose items have the same size.
   final FixedExtentScrollController controller;
 
@@ -40,6 +41,7 @@ class DateScrollView extends StatelessWidget {
   final bool isYearScrollView;
 
   final bool isMonthScrollView;
+
 
   double _getScrollViewWidth(BuildContext context) {
     String _longestText = '';

--- a/test/scroll_date_picker_test.dart
+++ b/test/scroll_date_picker_test.dart
@@ -1,1 +1,150 @@
-void main() {}
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:scroll_date_picker/scroll_date_picker.dart';
+import 'package:scroll_date_picker/src/widgets/date_scroll_view.dart';
+
+void main() {
+  group("picker ui validation", () {
+    testWidgets("when viewType is empty then shows default view for the locale",
+        (tester) async {
+      final selectedDate = DateTime(2021, 3, 5);
+
+      final targetView = MaterialApp(
+        home: ScrollDatePicker(
+          locale: Locale("en"),
+          selectedDate: selectedDate,
+          onDateTimeChanged: (DateTime value) {
+            //do nothing
+          },
+          viewType: [],
+        ),
+      );
+
+      await tester.pumpWidget(targetView);
+      await tester.pumpAndSettle(const Duration(seconds: 1));
+
+      expect(find.byType(DateScrollView), findsNWidgets(3));
+    });
+
+    testWidgets("when viewType is null then shows default view for the locale",
+        (tester) async {
+      final selectedDate = DateTime(2021, 3, 5);
+
+      final targetView = MaterialApp(
+        home: ScrollDatePicker(
+          locale: Locale("en"),
+          selectedDate: selectedDate,
+          onDateTimeChanged: (DateTime value) {
+            //do nothing
+          },
+          viewType: null,
+        ),
+      );
+
+      await tester.pumpWidget(targetView);
+      await tester.pumpAndSettle(const Duration(seconds: 1));
+
+      expect(find.byType(DateScrollView), findsNWidgets(3));
+    });
+
+    testWidgets(
+        "when viewType is not null or empty, then shows viewType list length's DateScrollView",
+        (tester) async {
+      final selectedDate = DateTime(2021, 3, 5);
+
+      final targetView = MaterialApp(
+        home: ScrollDatePicker(
+          locale: Locale("en"),
+          selectedDate: selectedDate,
+          onDateTimeChanged: (DateTime value) {
+            //do nothing
+          },
+          viewType: [DatePickerViewType.month],
+        ),
+      );
+
+      await tester.pumpWidget(targetView);
+      await tester.pumpAndSettle(const Duration(seconds: 1));
+
+      expect(find.byType(DateScrollView), findsNWidgets(1));
+      expect(find.byKey(const Key("month")), findsOneWidget);
+    });
+
+    testWidgets(
+        "when viewType is not null or empty, then shows viewType list length's DateScrollView",
+        (tester) async {
+      final selectedDate = DateTime(2021, 3, 5);
+
+      final targetView = MaterialApp(
+        home: ScrollDatePicker(
+          locale: Locale("en"),
+          selectedDate: selectedDate,
+          onDateTimeChanged: (DateTime value) {
+            //do nothing
+          },
+          viewType: [
+            DatePickerViewType.month,
+            DatePickerViewType.year,
+            DatePickerViewType.day
+          ],
+        ),
+      );
+
+      await tester.pumpWidget(targetView);
+      await tester.pumpAndSettle(const Duration(seconds: 1));
+
+      expect(find.byType(DateScrollView), findsNWidgets(3));
+      expect(find.byKey(const Key("month")), findsOneWidget);
+      expect(find.byKey(const Key("year")), findsOneWidget);
+      expect(find.byKey(const Key("day")), findsOneWidget);
+    });
+
+    testWidgets(
+        "when viewType is not null or empty, then shows viewType list length's DateScrollView",
+        (tester) async {
+      final selectedDate = DateTime(2021, 3, 5);
+
+      final targetView = MaterialApp(
+        home: ScrollDatePicker(
+          locale: Locale("en"),
+          selectedDate: selectedDate,
+          onDateTimeChanged: (DateTime value) {
+            //do nothing
+          },
+          viewType: [DatePickerViewType.year, DatePickerViewType.day],
+        ),
+      );
+
+      await tester.pumpWidget(targetView);
+      await tester.pumpAndSettle(const Duration(seconds: 1));
+
+      expect(find.byType(DateScrollView), findsNWidgets(2));
+      expect(find.byKey(const Key("year")), findsOneWidget);
+      expect(find.byKey(const Key("day")), findsOneWidget);
+    });
+
+    testWidgets(
+        "when viewType is not null or empty, then shows viewType list length's DateScrollView",
+        (tester) async {
+      final selectedDate = DateTime(2021, 3, 5);
+
+      final targetView = MaterialApp(
+        home: ScrollDatePicker(
+          locale: Locale("en"),
+          selectedDate: selectedDate,
+          onDateTimeChanged: (DateTime value) {
+            //do nothing
+          },
+          viewType: [DatePickerViewType.month, DatePickerViewType.day],
+        ),
+      );
+
+      await tester.pumpWidget(targetView);
+      await tester.pumpAndSettle(const Duration(seconds: 1));
+
+      expect(find.byType(DateScrollView), findsNWidgets(2));
+      expect(find.byKey(const Key("month")), findsOneWidget);
+      expect(find.byKey(const Key("day")), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
## Type of change

Please select PR type by entering x between [ ].

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring 
- [ ] Documentation content changes


<br><br>

## Description

With the DatePickerViewType option, you can set the year, month, or day view, and even the order in which it is displayed.
If the DatePickerViewType option is null or empty list, follow the existing Locale method.